### PR TITLE
Force Ubuntu base system for pandoc-extra to enable cross-platform AR…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -156,7 +156,7 @@ jobs:
       pandoc_version: ${{ matrix.version }}
 
   extra:
-    name: Extra (${{ matrix.stack }})
+    name: Extra (ubuntu)
     if: ${{ !contains(needs.prepare.outputs.matrix, '"stack":"static"') }}
     needs: [prepare, latex]
     strategy:
@@ -166,5 +166,6 @@ jobs:
     secrets: inherit
     with:
       addon: extra
-      base_system: ${{ matrix.stack }}
+      # Force Ubuntu base system for cross-platform ARM64 support (Alpine+extra is AMD64-only)
+      base_system: ubuntu
       pandoc_version: ${{ matrix.version }}


### PR DESCRIPTION
…M64 builds

Modified the extra image workflow to use Ubuntu base system instead of the matrix-determined base system to enable cross-platform ARM64 support.

Changes:
- Updated extra job in build.yaml to force `base_system: ubuntu`
- Updated job name to reflect Ubuntu usage: "Extra (ubuntu)"
- Added explanatory comment about Alpine+extra ARM64 compatibility issues

Background:
The build action restricts Alpine-based LaTeX/extra images to AMD64-only due to known compatibility issues with LaTeX packages on ARM64 Alpine. By forcing Ubuntu base system for pandoc-extra, we enable full cross-platform support (linux/amd64,linux/arm64) while maintaining Alpine compatibility for other image types.

This ensures pandoc-extra images are available for both x86_64 and ARM64 architectures, improving accessibility for ARM-based development environments.

🤖 Generated with [Claude Code](https://claude.ai/code)